### PR TITLE
`package_for_correction.py` - move to SCT?

### DIFF
--- a/preprocess/package_for_correction.py
+++ b/preprocess/package_for_correction.py
@@ -62,6 +62,11 @@ def get_parser():
         default='data_to_correct'
     )
     parser.add_argument(
+        '-suffix-files-seg',
+        help="FILES-SEG suffix. For example _seg or _label-SC_mask",
+        default='_seg'
+    )
+    parser.add_argument(
         '-v', '--verbose',
         help="Full verbose (for debugging)",
         action='store_true'
@@ -116,7 +121,7 @@ def main():
     for task, files in dict_yml.items():
         for file in files:
             if task == 'FILES_SEG':
-                suffix_label = '_seg'
+                suffix_label = args.suffix_files_seg		# e.g., _seg or _label-SC_mask
             elif task == 'FILES_LABEL':
                 suffix_label = None
             elif task == 'FILES_PMJ':

--- a/preprocess/utils.py
+++ b/preprocess/utils.py
@@ -12,22 +12,30 @@ import shutil
 from pathlib import Path
 from enum import Enum
 
+
 # BIDS utility tool
 def get_subject(file):
     """
     Get subject from BIDS file name
-    :param file:
-    :return: subject
+    :param file: input nifti filename (e.g., sub-001_ses-01_T1w.nii.gz) or file path
+    (e.g., /home/user/MRI/bids/derivatives/labels/sub-001/ses-01/anat/sub-001_ses-01_T1w.nii.gz
+    :return: subject_id: subject ID (e.g., sub-001)
     """
-    return file.split('_')[0]
+    subject = re.search('sub-(.*?)[_/]', file)                # [_/] slash or underscore
+    subject_id = subject.group(0)[:-1] if subject else ""    # [:-1] removes the last underscore or slash
+    return subject_id
+
 
 def get_ses(file):
     """
     Get session from BIDS file name
-    :param file:
-    :return: ses
+    :param file: input nifti filename (e.g., sub-001_ses-01_T1w.nii.gz) or file path
+    (e.g., /home/user/MRI/bids/derivatives/labels/sub-001/ses-01/anat/sub-001_ses-01_T1w.nii.gz
+    :return: sessionID: session ID (e.g., ses-01)
     """
-    return file.split('_')[1]
+    session = re.findall(r'ses-..', file)                   # .. - any two characters (e.g., ses-01 or ses-M0)
+    sessionID = session[0] if session else ""             # Return None if there is no session
+    return sessionID
 
 
 def get_contrast(file):


### PR DESCRIPTION
I needed to package data for manual correction for the INSPIRED project. I did not want to duplicate scripts; thus, I used the `package_for_correction.py` from this CanProCo repo. To make the script compatible with INSPIRED's filenames (e.g., `sub-torontoDCM001_acq-cspineAxial_T2w.nii.gz`), I had to make `get_subject` and `get_ses` functions more robust. Namely, I used regular expressions instead of the `.split` method in https://github.com/ivadomed/canproco/commit/2f06bf47061f4267b07fd613ceb192010ea650bf.

Also, for the `INSPIRED` project, I'm currently using the `_label-SC_mask.nii.gz` suffix instead of `_seg.nii.gz` (as discussed [here](https://github.com/neuropoly/data-management/issues/195#issuecomment-1369202235)). For this reason, I added an optional argument to the `package_for_correction.py` script in https://github.com/ivadomed/canproco/commit/5c5e2ac5b87feccde2732187ed492a2af71d2b18.

Since the `package_for_correction.py` script is more universal and can be used for any project, maybe, we could implement that into the SCT? 

For the context, `package_for_correction.py` was first introduced for [spine-generic](https://github.com/spine-generic/spine-generic/blob/master/spinegeneric/cli/package_for_correction.py). 

**Note:** I realize that this PR is not relevant to CanProCo itself, but I wanted to discuss this somewhere. After talking about it, the PR can be closed without merging.