### PR TITLE
Modification of `exclude.yml` file

### DIFF
--- a/exclude.yml
+++ b/exclude.yml
@@ -9,11 +9,14 @@
 - sub-mon009_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758684880
 - sub-mon032_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686509
 - sub-mon097_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686772
+- sub-mon113_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1760175861
 - sub-mon148_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686965
+- sub-mon152_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1760248384
 - sub-mon168_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687112
 - sub-mon191_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687352
 - sub-van176_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687602
 - sub-van206_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758688851
+- sub-tor014_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1760420705
 - sub-tor133_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758689928
 # STIR
 - sub-cal149_ses-M0   # FOV does not cover the whole SC in sagittal plane; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207

--- a/exclude.yml
+++ b/exclude.yml
@@ -6,14 +6,14 @@
 # PSIR
 - sub-mon118_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/43
 - sub-mon006_ses-M0   # FOV covers the whole brain. The SC has only C1-C6; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207
-- sub_mon009_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/54
-- sub_mon032_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/55
-- sub_mon097_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/56
-- sub-mon148_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/57
-- sub-mon168_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/58
-- sub-mon191_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/59
-- sub-van176_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/60
-- sub-van206_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/61
-- sub-tor133_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/62
+- sub-mon009_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758684880
+- sub-mon032_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686509
+- sub-mon097_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686772
+- sub-mon148_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758686965
+- sub-mon168_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687112
+- sub-mon191_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687352
+- sub-van176_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758687602
+- sub-van206_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758688851
+- sub-tor133_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/53#issuecomment-1758689928
 # STIR
 - sub-cal149_ses-M0   # FOV does not cover the whole SC in sagittal plane; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207

--- a/exclude.yml
+++ b/exclude.yml
@@ -5,6 +5,15 @@
 - sub-cal161          # Missing MT data
 # PSIR
 - sub-mon118_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/43
+- sub-mon006_ses-M0   # FOV covers the whole brain. The SC has only C1-C6; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207
+- sub_mon009_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/54
+- sub_mon032_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/55
+- sub_mon097_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/56
+- sub-mon148_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/57
+- sub-mon168_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/58
+- sub-mon191_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/59
+- sub-van176_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/60
+- sub-van206_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/61
+- sub-tor133_ses-M0   # Poor data quality; see https://github.com/ivadomed/canproco/issues/62
 # STIR
 - sub-cal149_ses-M0   # FOV does not cover the whole SC in sagittal plane; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207
-- sub-mon006_ses-M0   # FOV covers the whole brain. The SC has only C1-C6; see https://github.com/ivadomed/canproco/issues/22#issue-1568568207


### PR DESCRIPTION
Modification of the `exclude.yml` file: 
- moved sub-mon006 from stir to psir
- added 10 subjects from the observations in this [post](https://github.com/ivadomed/canproco/issues/53#issuecomment-1758022311)
- added more subjects seen during QC and during disc labeling