### PR TITLE
Implemented method to register lesion mask to MT space

### DIFF
--- a/lisa/spine.sh
+++ b/lisa/spine.sh
@@ -111,13 +111,36 @@ sct_apply_transfo -i ../../derivatives/lesion_masks/${SUBJECT_BASENAME}_lesion.n
 # Extract MTR in whole cord, GM, WM, WM regions (DC, LF, VF, CST) averaged between C2-C4
 
 mkdir -p ${SUBJECT}/mt/csv;
-
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 50 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_cord.csv -append 0;
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 52 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_gm.csv -append 0;
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 51 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_wm.csv -append 0;
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 53 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_dc.csv -append 0;
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 54 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_lf.csv -append 0;
 sct_extract_metric -i mtr.nii.gz -f label/atlas -method map -l 55 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_vf.csv -append 0;
+
+# Generate labels without lesions
+# First, invert lesion mask
+sct_maths -i lesion_new.nii.gz -sub 1 -o lesion_new_inv.nii.gz 
+sct_maths -i lesion_new_inv.nii.gz -mul -1 -o lesion_new_inv.nii.gz
+# Then, loop through all the atlas files and multiply it by the inverted lesion mask
+mkdir label/atlas_nolesion
+for file in label/atlas/*; do
+  # Check if it's a file (not a directory)
+  if [[ "$file" == *.nii.gz ]]; then
+    new_file="${file//atlas/atlas_nolesion}"
+    sct_maths -i $file -mul lesion_new_inv.nii.gz -o $new_file
+  fi
+done
+# Finally, copy infor_label.txt to atlas_nolesion
+cp label/atlas/info_label.txt label/atlas_nolesion/info_label.txt
+
+# Extract MTR in whole cord, GM, WM, WM regions (DC, LF, VF, CST) averaged between C2-C4 without lesion
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 50 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_cord_nolesion.csv -append 0;
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 52 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_gm_nolesion.csv -append 0;
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 51 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_wm_nolesion.csv -append 0;
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 53 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_dc_nolesion.csv -append 0;
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 54 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_lf_nolesion.csv -append 0;
+sct_extract_metric -i mtr.nii.gz -f label/atlas_nolesion -method map -l 55 -vert 2:4 -vertfile label/template/PAM50_levels.nii.gz -z 3:18 -o csv/mtr_vf_nolesion.csv -append 0;
 
 # Display end time
 

--- a/lisa/spine.sh
+++ b/lisa/spine.sh
@@ -14,8 +14,12 @@
 SUBJECT=$1
 qc=$2
 
+SUBJECT_BASENAME=`basename ${SUBJECT}`
+
+
 # Display start time
 echo "${SUBJECT}: spine.sh started at $(date +%x_%r)";
+echo "Subject: ${SUBJECT_BASENAME}"
 start=$(date +%s);
 
 # T2
@@ -98,7 +102,7 @@ sct_register_multimodal -i ../psir/psir.nii.gz -iseg ../psir/psir_seg.nii.gz -d 
 # Bring lesion mask onto mt_t1 space
 # TODO: extract subject name from absolute PATH
 
-sct_apply_transfo -i ../../derivatives/lesion_masks/CAN-03-RRM-092-M0_lesion.nii.gz -d mt_t1.nii.gz -w warp_psir2mt_t1.nii.gz -x linear -o lesion.nii.gz
+sct_apply_transfo -i ../../derivatives/lesion_masks/${SUBJECT_BASENAME}_lesion.nii.gz -d mt_t1.nii.gz -w warp_psir2mt_t1.nii.gz -x linear -o lesion.nii.gz
 
 # Extract MTR in whole cord, GM, WM, WM regions (DC, LF, VF, CST) averaged between C2-C4
 

--- a/lisa/spine.sh
+++ b/lisa/spine.sh
@@ -57,9 +57,13 @@ sct_process_segmentation -i t2_seg.nii.gz -vert 2:4 -vertfile ./label/template/P
 
 cd ${SUBJECT}/psir;
 
-# Segment spinal cord
+# Upsample PSIR image
 
-sct_deepseg -i psir.nii.gz -task seg_sc_contrast_agnostic -qc $qc;
+sct_resample -i psir.nii.gz -mm 0.7x0.7x0.7;
+
+# Segment spinal cord on upsampled PSIR image
+
+sct_deepseg -i psir_r.nii.gz -task seg_sc_contrast_agnostic -qc $qc;
 
 
 # MT
@@ -97,12 +101,12 @@ sct_compute_mtr -mt0 mt0_reg.nii.gz -mt1 mt1_reg.nii.gz;
 
 # Register PSIR -> mt_t1
 
-sct_register_multimodal -i ../psir/psir.nii.gz -iseg ../psir/psir_seg.nii.gz -d mt_t1.nii.gz -dseg mt_t1_seg.nii.gz -param step=1,type=seg,algo=centermass -x spline -o psir_reg.nii.gz -qc $qc;
+sct_register_multimodal -i ../psir/psir_r.nii.gz -iseg ../psir/psir_r_seg.nii.gz -d mt_t1.nii.gz -dseg mt_t1_seg.nii.gz -param step=1,type=seg,algo=centermass -x spline -o psir_r_reg.nii.gz -qc $qc;
 
 # Bring lesion mask onto mt_t1 space
 # TODO: extract subject name from absolute PATH
 
-sct_apply_transfo -i ../../derivatives/lesion_masks/${SUBJECT_BASENAME}_lesion.nii.gz -d mt_t1.nii.gz -w warp_psir2mt_t1.nii.gz -x linear -o lesion.nii.gz
+sct_apply_transfo -i ../../derivatives/lesion_masks/${SUBJECT_BASENAME}_lesion.nii.gz -d mt_t1.nii.gz -w warp_psir_r2mt_t1.nii.gz -x linear -o lesion.nii.gz
 
 # Extract MTR in whole cord, GM, WM, WM regions (DC, LF, VF, CST) averaged between C2-C4
 


### PR DESCRIPTION
This PR implements the following features:

- linearly register SC lesion masks in subject PSIR to subject MT space
- calculate MTR for ROIs excluding SC lesions

> [!WARNING]  
> The script is now calling sct_deepseg (to segment the PSIR image), which requires SCT v6.3 or later.

TODO:

- [x] Register PSIR to MT
- [x] Apply transformation to lesion mask
- [x] Get basename of subject
- [ ] Add QC for registered lesion 👉  on hold: https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/4491
- [x] Calculate MTR for ROIs excluding SC lesions

Fixes #91